### PR TITLE
商品購入機能実装

### DIFF
--- a/ES図.dio
+++ b/ES図.dio
@@ -1,6 +1,6 @@
 <mxfile host="65bd71144e">
     <diagram id="TQfzECb6IaOLQgD7lEZ8" name="ページ1">
-        <mxGraphModel dx="406" dy="572" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+        <mxGraphModel dx="827" dy="411" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
@@ -42,7 +42,7 @@
                 <mxCell id="13" value="address" style="swimlane;whiteSpace=wrap;html=1;fillColor=#1ba1e2;fontColor=#ffffff;strokeColor=#006EAF;" parent="1" vertex="1">
                     <mxGeometry x="490" y="340" width="210" height="230" as="geometry"/>
                 </mxCell>
-                <mxCell id="14" value="&lt;ul&gt;&lt;li&gt;postal_code&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;text-align: center;&quot;&gt;prefecture_id&lt;/span&gt;&lt;br&gt;&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;text-align: center;&quot;&gt;city&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;text-align: center;&quot;&gt;house_number&lt;/span&gt;&lt;/li&gt;&lt;li style=&quot;text-align: center;&quot;&gt;buiding_name&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;text-align: center;&quot;&gt;phone_number&lt;br&gt;&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;text-align: center;&quot;&gt;order&lt;/span&gt;&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" parent="13" vertex="1">
+                <mxCell id="14" value="&lt;ul&gt;&lt;li&gt;postal_code&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;text-align: center;&quot;&gt;prefecture_id&lt;/span&gt;&lt;br&gt;&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;text-align: center;&quot;&gt;city&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;text-align: center;&quot;&gt;house_number&lt;/span&gt;&lt;/li&gt;&lt;li style=&quot;text-align: center;&quot;&gt;building_name&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;text-align: center;&quot;&gt;phone_number&lt;br&gt;&lt;/span&gt;&lt;/li&gt;&lt;li&gt;&lt;span style=&quot;text-align: center;&quot;&gt;order&lt;/span&gt;&lt;/li&gt;&lt;/ul&gt;" style="text;strokeColor=none;fillColor=none;html=1;whiteSpace=wrap;verticalAlign=middle;overflow=hidden;" parent="13" vertex="1">
                     <mxGeometry x="10" y="40" width="160" height="170" as="geometry"/>
                 </mxCell>
                 <mxCell id="21" value="" style="edgeStyle=segmentEdgeStyle;endArrow=ERone;html=1;curved=0;rounded=0;endSize=8;startSize=8;strokeWidth=2;endFill=0;startArrow=ERone;startFill=0;" parent="1" edge="1">

--- a/Gemfile
+++ b/Gemfile
@@ -84,4 +84,5 @@ gem 'devise'
 gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 gem 'active_hash'
-
+gem 'payjp'
+gem 'gon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -110,6 +112,14 @@ GEM
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -138,10 +148,14 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     minitest (5.18.1)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     mysql2 (0.5.5)
     net-imap (0.3.6)
       date
@@ -152,6 +166,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.9)
     nokogiri (1.15.3-x86_64-darwin)
       racc (~> 1.4)
@@ -160,6 +175,8 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
+    payjp (0.0.10)
+      rest-client (~> 2.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -206,9 +223,16 @@ GEM
     regexp_parser (2.8.1)
     reline (0.3.6)
       io-console (~> 0.5)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.5)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
@@ -265,6 +289,9 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
     unicorn (6.1.0)
       kgio (~> 2.6)
@@ -299,11 +326,13 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  gon
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
   mini_magick
   mysql2 (~> 0.5)
+  payjp
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.0)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 - belongs_to :user
 - has_one :order
 
-## oders 
+## orders 
 | Column             | Type       | Options                        |
 | ------------------ | ---------- | ------------------------------ |
 | user               | references | null: false, foreign_key: true |
@@ -48,14 +48,14 @@
 - belongs_to :item
 - belongs_to :user
 
-### Addresss
+### Addresses
 | Column               | Type         | Options                        |
 | ---------------------| -------------| ------------------------------ |
 | postal_code          | string       | null: false                    |
 | prefecture_id        | integer      | null: false                    |
 | city                 | string       | null: false                    |
 | house_number         | string       | null: flase                    |
-| buiding_name         | string       |                                |
+| building_name        | string       |                                |
 | phone_number         | string       | null: false                    | 
 | order                | references   | null: false, foreign_key: true |                   |
 ### Association

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -49,10 +49,11 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
+
   def move_to_index
-      unless current_user == @item.user
+    unless current_user == @item.user && @item.order.nil?
         redirect_to root_path
-      end   
+    end   
   end
 
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -22,7 +22,7 @@ class OrdersController < ApplicationController
     private
 
     def order_params
-        params.require(:order_address).permit( :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number).merge(item_id: @item.id).merge(user_id: current_user.id).merge(token: params[:token])
+      params.require(:order_address).permit(:postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number).merge(item_id: @item.id, user_id: current_user.id, token: params[:token])
     end
 
     def pay_item

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -22,7 +22,7 @@ class OrdersController < ApplicationController
     private
 
     def order_params
-        params.require(:order_address).permit( :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number, :order_id).merge(item_id: @item.id).merge(user_id: current_user.id).merge(token: params[:token])
+        params.require(:order_address).permit( :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number).merge(item_id: @item.id).merge(user_id: current_user.id).merge(token: params[:token])
     end
 
     def pay_item

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -5,18 +5,14 @@ class OrdersController < ApplicationController
 
     def index
         gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
-        #@order = Item.find(params[:id])
-        @item = Item.find(params[:item_id])
         @order_address = OrderAddress.new
     end
 
     def create
-        @item = Item.find(params[:item_id])
         @order_address = OrderAddress.new(order_params) 
         if @order_address.valid?
           pay_item
           @order_address.save
-          #@order_address.item.update(sold_out: true)
           redirect_to root_path
         else
           render :index, status: :unprocessable_entity
@@ -26,7 +22,6 @@ class OrdersController < ApplicationController
     private
 
     def order_params
-        #params.require(:order_address).permit( :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number, :order_id, :item_id).merge(user_id: current_user.id)
         params.require(:order_address).permit( :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number, :order_id).merge(item_id: @item.id).merge(user_id: current_user.id).merge(token: params[:token])
     end
 
@@ -41,7 +36,6 @@ class OrdersController < ApplicationController
 
     def move_to_item_index
       @item = Item.find(params[:item_id])
-      @order_address = OrderAddress.new
       if current_user == @item.user
         redirect_to root_path
       elsif !@item.order.nil?

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,6 +2,7 @@ class OrdersController < ApplicationController
     before_action :authenticate_user!, except: :index
 
     def index
+        gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
         #@order = Item.find(params[:id])
         @item = Item.find(params[:item_id])
         @order_address = OrderAddress.new
@@ -11,6 +12,7 @@ class OrdersController < ApplicationController
         @item = Item.find(params[:item_id])
         @order_address = OrderAddress.new(order_params) 
         if @order_address.valid?
+          pay_item
           @order_address.save
           redirect_to root_path
         else
@@ -22,7 +24,16 @@ class OrdersController < ApplicationController
 
     def order_params
         #params.require(:order_address).permit( :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number, :order_id, :item_id).merge(user_id: current_user.id)
-        params.require(:order_address).permit( :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number, :order_id).merge(item_id: @item.id).merge(user_id: current_user.id)
+        params.require(:order_address).permit( :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number, :order_id).merge(item_id: @item.id).merge(user_id: current_user.id).merge(token: params[:token])
+    end
+
+    def pay_item
+      Payjp.api_key = ENV["PAYJP_SECRET_KEY"]  # 自身のPAY.JPテスト秘密鍵を記述しましょう
+      Payjp::Charge.create(
+        amount: @item.price,
+        card: order_params[:token],    # カードトークン
+        currency: 'jpy'                 # 通貨の種類（日本円）
+      )
     end
 
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,5 +1,7 @@
 class OrdersController < ApplicationController
     before_action :authenticate_user!, except: :index
+    before_action :move_to_item_index
+    before_action :move_to_signin
 
     def index
         gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
@@ -14,6 +16,7 @@ class OrdersController < ApplicationController
         if @order_address.valid?
           pay_item
           @order_address.save
+          #@order_address.item.update(sold_out: true)
           redirect_to root_path
         else
           render :index, status: :unprocessable_entity
@@ -34,6 +37,22 @@ class OrdersController < ApplicationController
         card: order_params[:token],    # カードトークン
         currency: 'jpy'                 # 通貨の種類（日本円）
       )
+    end
+
+    def move_to_item_index
+      @item = Item.find(params[:item_id])
+      @order_address = OrderAddress.new
+      if current_user == @item.user
+        redirect_to root_path
+      elsif !@item.order.nil?
+        redirect_to root_path
+      end
+    end
+
+    def move_to_signin
+      unless user_signed_in?
+        redirect_to new_user_session_path
+      end
     end
 
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,28 @@
+class OrdersController < ApplicationController
+    before_action :authenticate_user!, except: :index
+
+    def index
+        #@order = Item.find(params[:id])
+        @item = Item.find(params[:item_id])
+        @order_address = OrderAddress.new
+    end
+
+    def create
+        @item = Item.find(params[:item_id])
+        @order_address = OrderAddress.new(order_params) 
+        if @order_address.valid?
+          @order_address.save
+          redirect_to root_path
+        else
+          render :index, status: :unprocessable_entity
+        end
+    end
+
+    private
+
+    def order_params
+        #params.require(:order_address).permit( :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number, :order_id, :item_id).merge(user_id: current_user.id)
+        params.require(:order_address).permit( :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number, :order_id).merge(item_id: @item.id).merge(user_id: current_user.id)
+    end
+
+end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,10 +1,8 @@
 class OrdersController < ApplicationController
-    before_action :authenticate_user!, except: :index
+    before_action :authenticate_user!
     before_action :move_to_item_index
-    before_action :move_to_signin
 
     def index
-        gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
         @order_address = OrderAddress.new
     end
 
@@ -35,6 +33,7 @@ class OrdersController < ApplicationController
     end
 
     def move_to_item_index
+      gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
       @item = Item.find(params[:item_id])
       if current_user == @item.user
         redirect_to root_path
@@ -43,10 +42,5 @@ class OrdersController < ApplicationController
       end
     end
 
-    def move_to_signin
-      unless user_signed_in?
-        redirect_to new_user_session_path
-      end
-    end
-
+   
 end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,2 @@
+module OrdersHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import "price"
+import "card"

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,0 +1,32 @@
+const pay = () => {
+    const publicKey = gon.public_key
+    const payjp = Payjp(publicKey)// PAY.JPテスト公開鍵
+    const elements = payjp.elements();
+    const numberElement = elements.create('cardNumber');
+    const expiryElement = elements.create('cardExpiry');
+    const cvcElement = elements.create('cardCvc');
+  
+    numberElement.mount('#number-form');
+    expiryElement.mount('#expiry-form');
+    cvcElement.mount('#cvc-form');
+  
+    const form = document.getElementById('charge-form')
+    form.addEventListener("submit", (e) => {
+      payjp.createToken(numberElement).then(function (response) {
+        if (response.error) {
+        } else {
+          const token = response.id;
+          const renderDom = document.getElementById("charge-form");
+          const tokenObj = `<input value=${token} name='token' type="hidden">`;
+          renderDom.insertAdjacentHTML("beforeend", tokenObj);
+        }
+        numberElement.clear();
+        expiryElement.clear();
+        cvcElement.clear();
+        document.getElementById("charge-form").submit();
+      });
+      e.preventDefault();
+    });
+  };
+  
+  window.addEventListener("turbo:load", pay);

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,3 @@
+class Address < ApplicationRecord
+    belongs_to :order
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,6 @@
 class Item < ApplicationRecord
   belongs_to :user
+  has_one :order
   has_one_attached :image
 
   extend ActiveHash::Associations::ActiveRecordExtensions

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,5 @@
+class Order < ApplicationRecord
+has_one :address
+belongs_to :item
+belongs_to :user
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,4 +2,6 @@ class Order < ApplicationRecord
 has_one :address
 belongs_to :item
 belongs_to :user
+validates :user_id, presence: true 
+validates :item_id, presence: true 
 end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -1,21 +1,20 @@
 class OrderAddress
     include ActiveModel::Model
-    attr_accessor :user_id, :item_id, :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number, :order_id, :token
+    attr_accessor :user_id, :item_id, :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number, :token
   
     with_options presence: true do
       validates :postal_code, format: {with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)"}
       validates :prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
       validates :city
       validates :house_number
-      validates :phone_number, numericality: { only_integer: true, message: 'is invalid. Input only number' },
-                               length: { minimum: 10, message: 'is too short' }
+      validates :phone_number, numericality: { message: 'is invalid. Input only number' },
+                               format: { with: /\A\d{10,11}\z/, message: 'is invalid. Phone number is too short'}
       validates :user_id
       validates :item_id
-      validates :token, presence: true
+      validates :token
     end
   
     def save
-      #order = Order.create(user_id: user_id, item_id: @item_id)
       order = Order.create(user_id: user_id, item_id: item_id)
       Address.create(postal_code: postal_code, prefecture_id: prefecture_id, city: city, house_number: house_number, building_name: building_name, phone_number: phone_number, order_id: order.id)
     end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -1,0 +1,22 @@
+class OrderAddress
+    include ActiveModel::Model
+    attr_accessor :user_id, :item_id, :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number, :order_id
+  
+    with_options presence: true do
+      validates :postal_code, format: {with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)"}
+      validates :prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
+      validates :city
+      validates :house_number
+      validates :phone_number, numericality: { only_integer: true },
+                               length: { minimum: 10, maximum: 11 }
+      validates :user_id
+      validates :item_id
+      #validates :order_id  
+    end
+  
+    def save
+      #order = Order.create(user_id: user_id, item_id: @item_id)
+      order = Order.create(user_id: user_id, item_id: item_id)
+      Address.create(postal_code: postal_code, prefecture_id: prefecture_id, city: city, house_number: house_number, building_name: building_name, phone_number: phone_number, order_id: order.id)
+    end
+end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -7,8 +7,8 @@ class OrderAddress
       validates :prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
       validates :city
       validates :house_number
-      validates :phone_number, numericality: { only_integer: true },
-                               length: { minimum: 10, maximum: 11 }
+      validates :phone_number, numericality: { only_integer: true, message: 'is invalid. Input only number' },
+                               length: { minimum: 10, message: 'is too short' }
       validates :user_id
       validates :item_id
       #validates :order_id  

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -1,6 +1,6 @@
 class OrderAddress
     include ActiveModel::Model
-    attr_accessor :user_id, :item_id, :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number, :order_id
+    attr_accessor :user_id, :item_id, :postal_code, :prefecture_id, :city, :house_number, :building_name, :phone_number, :order_id, :token
   
     with_options presence: true do
       validates :postal_code, format: {with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)"}
@@ -11,7 +11,7 @@ class OrderAddress
                                length: { minimum: 10, message: 'is too short' }
       validates :user_id
       validates :item_id
-      #validates :order_id  
+      validates :token, presence: true
     end
   
     def save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,5 @@ class User < ApplicationRecord
     validates :date_birth
   end
   has_many :items
+  has_many :orders
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,15 +131,14 @@
     <% @items.each do |item| %>
       <li class='list'>
         <%= link_to item_path(item.id) do %>
-        <%#= link_to '/items/show', method: :GET do %>
         <div class='item-img-content'>
           <%= image_tag (item.image), class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
+          <% if !item.order.nil? %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+          <% end %>
 
         </div>
         <div class='item-info'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -9,7 +9,6 @@
     <div class="item-img-content">
       <%= image_tag @item.image, class: "item-box-img" %>
       <% if !@item.order.nil? %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,12 +8,12 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image, class: "item-box-img" %>
-      <%#% if @item.sold.out? %>
+      <% if !@item.order.nil? %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# end %>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -26,6 +26,7 @@
 
     
     <% if user_signed_in? %>
+    <% if @item.order.nil? %>
     <% if current_user.id == @item.user_id %>
 
     <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
@@ -33,6 +34,7 @@
     <%= link_to "削除", item_path(@item), data: {turbo_method: :delete }, class:"item-destroy" %>
     <% else  %>
     <%= link_to "購入画面に進む", item_orders_path(@item.id),class:"item-red-btn"%>
+    <% end %>
     <% end %>
     <% end %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,12 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image, class: "item-box-img" %>
+      <%#% if @item.sold.out? %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%# end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -30,9 +31,8 @@
     <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", item_path(@item), data: {turbo_method: :delete }, class:"item-destroy" %>
-    <%#= link_to "削除", "/items/#{item.id}", data: { turbo_method: :delete }, class:"item-destroy" %>
     <% else  %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <%= link_to "購入画面に進む", item_orders_path(@item.id),class:"item-red-btn"%>
     <% end %>
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
+  <script type="text/javascript" src="https://js.pay.jp/v2/pay.js"></script>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   <%= javascript_importmap_tags %>
 </head>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -33,6 +33,7 @@
 
     <%#= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
     <%= form_with model: @order_address, url: item_orders_path, id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -7,14 +7,14 @@
     </h1>
     <%# 購入内容の表示 %>
     <div class='buy-item-info'>
-      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <%= image_tag @item.image, class: 'buy-item-img' %>
       <div class='buy-item-right-content'>
         <h2 class='buy-item-text'>
-          <%= "商品名" %>
+          <%= @item.name %>
         </h2>
         <div class='buy-item-price'>
-          <p class='item-price-text'>¥<%= '999,999,999' %></p>
-          <p class='item-price-sub-text'><%= '配送料負担' %></p>
+          <p class='item-price-text'>¥<%= @item.price %></p>
+          <p class='item-price-sub-text'><%= @item.shipping_fee_status.name %></p>
         </div>
       </div>
     </div>
@@ -26,12 +26,13 @@
         支払金額
       </h1>
       <p class='item-payment-price'>
-        ¥<%= "販売価格" %>
+        ¥<%= @item.price %>
       </p>
     </div>
     <%# /支払額の表示 %>
 
-    <%= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%#= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%= form_with model: @order_address, url: item_orders_path, id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>
@@ -79,42 +80,42 @@
           <label class="form-text">郵便番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+        <%= f.text_field :postal_code, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">都道府県</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"prefecture"}) %>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">市区町村</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+        <%= f.text_field :city, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">番地</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+        <%= f.text_field :house_number, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">建物名</label>
           <span class="form-any">任意</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+        <%= f.text_field :building_name, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
       </div>
       <div class="form-group">
         <div class='form-text-wrap'>
           <label class="form-text">電話番号</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+        <%= f.text_field :phone_number, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
       </div>
     </div>
     <%# /配送先の入力 %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -32,7 +32,6 @@
     <%# /支払額の表示 %>
 
     <%= include_gon %>
-    <%#= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
     <%= form_with model: @order_address, url: item_orders_path, id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
     <%= render 'shared/error_messages', model: f.object %>
     <%# カード情報の入力 %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -31,6 +31,7 @@
     </div>
     <%# /支払額の表示 %>
 
+    <%= include_gon %>
     <%#= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
     <%= form_with model: @order_address, url: item_orders_path, id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
     <%= render 'shared/error_messages', model: f.object %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -57,4 +57,5 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+  config.active_job.queue_adapter = :inline #追記
 end

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,3 +6,4 @@ pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "price", to: "price.js"
+pin "card", to: "card.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items
+  resources :items do
+    resources :orders, only: [:index, :create]
+  end
 end

--- a/db/migrate/20230802074652_create_orders.rb
+++ b/db/migrate/20230802074652_create_orders.rb
@@ -1,0 +1,10 @@
+class CreateOrders < ActiveRecord::Migration[7.0]
+  def change
+    create_table :orders do |t|
+      t.references :user,                   null: false, foreign_key: true
+      t.references :item,                   null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230802074733_create_addresses.rb
+++ b/db/migrate/20230802074733_create_addresses.rb
@@ -1,0 +1,16 @@
+class CreateAddresses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :addresses do |t|
+
+      t.string :postal_code,                  null: false
+      t.integer :prefecture_id,               null: false
+      t.string :city,                         null: false
+      t.string :house_number,                 null: false
+      t.string :building_name,                null: false
+      t.string :phone_number,                 null: false
+      t.references :order,                   null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230802074733_create_addresses.rb
+++ b/db/migrate/20230802074733_create_addresses.rb
@@ -6,7 +6,7 @@ class CreateAddresses < ActiveRecord::Migration[7.0]
       t.integer :prefecture_id,               null: false
       t.string :city,                         null: false
       t.string :house_number,                 null: false
-      t.string :building_name,                null: false
+      t.string :building_name              
       t.string :phone_number,                 null: false
       t.references :order,                   null: false, foreign_key: true
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_28_121247) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_02_074733) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -39,6 +39,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_28_121247) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "addresses", charset: "utf8", force: :cascade do |t|
+    t.string "postal_code", null: false
+    t.integer "prefecture_id", null: false
+    t.string "city", null: false
+    t.string "house_number", null: false
+    t.string "building_name", null: false
+    t.string "phone_number", null: false
+    t.bigint "order_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_addresses_on_order_id"
+  end
+
   create_table "items", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.text "info", null: false
@@ -52,6 +65,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_28_121247) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "orders", charset: "utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "users", charset: "utf8", force: :cascade do |t|
@@ -74,5 +96,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_28_121247) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "addresses", "orders"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
 end

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :address do
+    
+  end
+end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -7,7 +7,5 @@ FactoryBot.define do
     house_number        { '1-1' }
     building_name       { '東京ハイツ' }
     phone_number        { '09012345678' }
-    user_id             { 1 }
-    item_id             { 1 }
   end
 end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :order_address do
+    postal_code         { '123-4567' }
+    prefecture_id       { 2 }
+    city                { '東京都' }
+    house_number        { '1-1' }
+    building_name       { '東京ハイツ' }
+    phone_number        { '09012345678' }
+    user_id             { 1 }
+    item_id             { 1 }
+  end
+end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :order_address do
+    token               {"tok_abcdefghijk00000000000000000"}
     postal_code         { '123-4567' }
     prefecture_id       { 2 }
     city                { '東京都' }

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :order do
+    
+  end
+end

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the OrdersHelper. For example:
+#
+# describe OrdersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe OrdersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -68,6 +68,11 @@ RSpec.describe OrderAddress, type: :model do
         @order_address.valid?
         expect( @order_address.errors.full_messages).to include("Item can't be blank")
       end
+      it "tokenが空では登録できないこと" do
+        @order_address.token = nil
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Token can't be blank")
+      end
 
 
 

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe OrderAddress, type: :model do
+  before do 
+    @order_address = FactoryBot.build(:order_address)
+  end
+
+  describe '商品を購入する' do
+    context '商品が購入できる場合' do
+      it '全ての値が正しく入力されていれば、保存できる' do
+        expect(@order_address).to be_valid
+      end
+      it 'building_nameは空でも保存できること ' do
+        @order_address.building_name = nil
+        expect(@order_address).to be_valid
+      end
+    end
+    context '商品が購入できない場合' do
+      it 'postal_codeが空だと保存できないこと' do
+        @order_address.postal_code = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Postal code can't be blank")
+      end
+      it 'postal_codeが半角のハイフンを含んだ正しい形式でないと保存できないこと' do
+        @order_address.postal_code = '1234567'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include('Postal code is invalid. Include hyphen(-)')
+      end
+      it 'Prefectureが空では出品できない' do
+        @order_address.prefecture_id = 1
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Prefecture can't be blank")
+      end
+      it 'cityが空だと保存できないこと' do
+        @order_address.city = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("City can't be blank")
+      end
+      it 'houser_numberが空だと保存できないこと' do
+        @order_address.house_number = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("House number can't be blank")
+      end
+      it 'phone_numberが空だと保存できないこと' do
+        @order_address.phone_number = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone number can't be blank")
+      end
+      it 'phone_numberが10桁以上でないと保存できないこと' do
+        @order_address.phone_number = 12345678
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone number is too short")
+      end
+
+      it 'phone_numberが半角数値でない場合、保存できない' do
+        @order_address.phone_number= 'abcdefghtq'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone number is invalid. Input only number")
+      end
+      it 'userが紐付いていないと保存できない' do
+        @order_address.user_id = ''
+        @order_address.valid?
+        expect( @order_address.errors.full_messages).to include("User can't be blank")
+      end
+
+      it 'itemが紐付いていないと保存できない' do
+        @order_address.item_id = ''
+        @order_address.valid?
+        expect( @order_address.errors.full_messages).to include("Item can't be blank")
+      end
+
+
+
+    end
+  end
+end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe OrderAddress, type: :model do
-  before do 
-    @order_address = FactoryBot.build(:order_address)
+  before do
+    user = FactoryBot.create(:user)
+    item = FactoryBot.create(:item)
+    @order_address = FactoryBot.build(:order_address,user_id: user.id, item_id: item.id)
   end
 
   describe '商品を購入する' do
@@ -49,7 +51,13 @@ RSpec.describe OrderAddress, type: :model do
       it 'phone_numberが10桁以上でないと保存できないこと' do
         @order_address.phone_number = 12345678
         @order_address.valid?
-        expect(@order_address.errors.full_messages).to include("Phone number is too short")
+        expect(@order_address.errors.full_messages).to include("Phone number is invalid. Phone number is too short")
+      end
+
+      it 'phone_numberが10桁以上でないと保存できないこと' do
+        @order_address.phone_number = 123456781234
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Phone number is invalid. Phone number is too short")
       end
 
       it 'phone_numberが半角数値でない場合、保存できない' do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/orders_request_spec.rb
+++ b/spec/requests/orders_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Orders", type: :request do
+
+end


### PR DESCRIPTION
＃What
 1.Formオブジェクトを作成
2 .購入機能に必要なモデルやコントローラーを作成
3.購入のためのフォームを実装
4.フォームの情報を保存できるようにする
5.エラーが表示されるようにする
6.テストコードを実装
7.PAY.JPを利用してクレジットカード決済を実装
8.売却済み商品にsold out を表示するよう設定

＃Why
商品購入機能実装のため
ーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーー
- 必要な情報を適切に入力して「購入」ボタンを押すと、商品の購入ができる動画
https://gyazo.com/525358a5e5605040ccb0e8d1e59cdf2b

- 入力に問題がある状態で「購入」ボタンが押された場合、情報は受け入れられず、購入ページでエラーメッセージが表示される動画
https://gyazo.com/90d04d27a604e33d7b60ae835a23d139

- ログイン状態の場合でも、URLを直接入力して自身が出品していない売却済み商品の商品購入ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/8f5f31c6aeda76ce8d1b9c37a19e67d0

- ログイン状態の場合でも、URLを直接入力して自身が出品した商品の商品購入ページに遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/0e30ed96338695849db838522105d0a4

https://gyazo.com/835fa63fd461a0f808611b182e9f49f0

- ログアウト状態の場合は、URLを直接入力して商品購入ページに遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/10596f4b3df0b7c0476e2a489b879e21

- 売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品一覧機能実装時に未実装であった場合）
https://gyazo.com/f83b71c27e230979a6b0f3a5b83cc3df

- 売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品詳細機能実装時に未実装であった場合）
https://gyazo.com/0b92d8fe2c887f5d48a5b844f1825ee8

- ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されない動画（商品詳細機能実装時に未実装であった場合）

https://gyazo.com/0b92d8fe2c887f5d48a5b844f1825ee8

- ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（商品情報編集機能実装時に未実装であった場合）

https://gyazo.com/4798db7e86259883342ba9fda503a06b

- テスト結果の画像
https://gyazo.com/3e5232be6452d7dcd93eef64f9589d10
